### PR TITLE
tests, fix and lemmatizer

### DIFF
--- a/config/bundles/bluima.preprocessing_0.1.json
+++ b/config/bundles/bluima.preprocessing_0.1.json
@@ -22,6 +22,7 @@
   "engines" : [
       {
         "name" : "ChunkAnnotator",
+        "description" : "OpenNLP Chunker provides chunks to tokens in IOB format (e.g. B-NP, I-VP)",
         "class" : "ch.epfl.bbp.uima.ae.ChunkAnnotator",
         "parameters" : {
           "posTagSetPreference" : [ "de.julielab.jules.types.GeniaPOSTag" ],
@@ -29,6 +30,7 @@
         }
       }, {
         "name" : "PosTagAnnotator",
+        "description" : "OpenNLP Part Of Speech Tagger. This annotator assumes that sentences and tokens have been annotated first.",
         "class" : "ch.epfl.bbp.uima.ae.PosTagAnnotator",
         "parameters" : {
           "tagDict" : [ "ch.epfl.bbp.nlp.res.tag.dict.GeniaResource" ],
@@ -39,12 +41,14 @@
         }
       }, {
         "name" : "SentenceAnnotator",
+        "description" : "Sentence splitter, based on OpenNLP's MaxEnt SentenceDetector, and trained on biomedical corpora (PennBio or Genia corpora).",
         "class" : "ch.epfl.bbp.uima.ae.SentenceAnnotator",
         "parameters" : {
           "model" : [ "ch.epfl.bbp.nlp.res.sentence.GeniaResource" ]
         }
       }, {
         "name" : "TokenAnnotator",
+        "description" : "OpenNLP Tokenizer. This engine assumes that sentences have been annotated first.",
         "class" : "ch.epfl.bbp.uima.ae.TokenAnnotator",
         "parameters" : {
           "model" : [ "ch.epfl.bbp.nlp.res.token.GeniaResource" ]

--- a/config/bundles/bluima.preprocessing_0.1.json
+++ b/config/bundles/bluima.preprocessing_0.1.json
@@ -1,58 +1,92 @@
 {
-  "name" : "bluima.preprocessing",
-  "domain" : "bluima",
-  "version" : "0.1",
-  "dependencies" : [
-      {
-        "value" : "ch.epfl.bbp.nlp:bluima_opennlp:0.1"
-      }, {
-        "value" : "ch.epfl.bbp.nlp:bluima_chunker_genia:0.1"
-      }, {
-        "value" : "ch.epfl.bbp.nlp:bluima_postagger_genia:0.1"
-      }, {
-        "value" : "ch.epfl.bbp.nlp:bluima_sentence_detector_genia:0.1"
-      }, {
-        "value" : "ch.epfl.bbp.nlp:bluima_sentence_detector_pennbio:0.1"
-      }, {
-        "value" : "ch.epfl.bbp.nlp:bluima_tagdict_genia:0.1"
-      }, {
-        "value" : "ch.epfl.bbp.nlp:bluima_tokenizer_genia:0.1"
-      }
+  "name": "bluima.preprocessing",
+  "domain": "bluima",
+  "version": "0.1",
+  "dependencies": [
+    {
+      "value": "ch.epfl.bbp.nlp:bluima_opennlp:0.1"
+    },
+    {
+      "value": "ch.epfl.bbp.nlp:bluima_chunker_genia:0.1"
+    },
+    {
+      "value": "ch.epfl.bbp.nlp:bluima_postagger_genia:0.1"
+    },
+    {
+      "value": "ch.epfl.bbp.nlp:bluima_sentence_detector_genia:0.1"
+    },
+    {
+      "value": "ch.epfl.bbp.nlp:bluima_sentence_detector_pennbio:0.1"
+    },
+    {
+      "value": "ch.epfl.bbp.nlp:bluima_tagdict_genia:0.1"
+    },
+    {
+      "value": "ch.epfl.bbp.nlp:bluima_tokenizer_genia:0.1"
+    },
+    {
+      "value": "ch.epfl.bbp.nlp:bluima_commons:0.1"
+    }
   ],
-  "engines" : [
-      {
-        "name" : "ChunkAnnotator",
-        "description" : "OpenNLP Chunker provides chunks to tokens in IOB format (e.g. B-NP, I-VP)",
-        "class" : "ch.epfl.bbp.uima.ae.ChunkAnnotator",
-        "parameters" : {
-          "posTagSetPreference" : [ "de.julielab.jules.types.GeniaPOSTag" ],
-          "model" : [ "ch.epfl.bbp.nlp.res.chunk.GeniaResource" ]
-        }
-      }, {
-        "name" : "PosTagAnnotator",
-        "description" : "OpenNLP Part Of Speech Tagger. This annotator assumes that sentences and tokens have been annotated first.",
-        "class" : "ch.epfl.bbp.uima.ae.PosTagAnnotator",
-        "parameters" : {
-          "tagDict" : [ "ch.epfl.bbp.nlp.res.tag.dict.GeniaResource" ],
-          "model" : [ "ch.epfl.bbp.nlp.res.tag.GeniaResource" ],
-          "tagset" : [ "de.julielab.jules.types.GeniaPOSTag" ],
-          "caseSensitive" : [ "false" ],
-          "useTagdict" : [ "true" ]
-        }
-      }, {
-        "name" : "SentenceAnnotator",
-        "description" : "Sentence splitter, based on OpenNLP's MaxEnt SentenceDetector, and trained on biomedical corpora (PennBio or Genia corpora).",
-        "class" : "ch.epfl.bbp.uima.ae.SentenceAnnotator",
-        "parameters" : {
-          "model" : [ "ch.epfl.bbp.nlp.res.sentence.GeniaResource" ]
-        }
-      }, {
-        "name" : "TokenAnnotator",
-        "description" : "OpenNLP Tokenizer. This engine assumes that sentences have been annotated first.",
-        "class" : "ch.epfl.bbp.uima.ae.TokenAnnotator",
-        "parameters" : {
-          "model" : [ "ch.epfl.bbp.nlp.res.token.GeniaResource" ]
-        }
+  "engines": [
+    {
+      "name": "ChunkAnnotator",
+      "description": "OpenNLP Chunker provides chunks to tokens in IOB format (e.g. B-NP, I-VP)",
+      "class": "ch.epfl.bbp.uima.ae.ChunkAnnotator",
+      "parameters": {
+        "posTagSetPreference": [
+          "de.julielab.jules.types.GeniaPOSTag"
+        ],
+        "model": [
+          "ch.epfl.bbp.nlp.res.chunk.GeniaResource"
+        ]
       }
+    },
+    {
+      "name": "PosTagAnnotator",
+      "description": "OpenNLP Part Of Speech Tagger. This annotator assumes that sentences and tokens have been annotated first.",
+      "class": "ch.epfl.bbp.uima.ae.PosTagAnnotator",
+      "parameters": {
+        "tagDict": [
+          "ch.epfl.bbp.nlp.res.tag.dict.GeniaResource"
+        ],
+        "model": [
+          "ch.epfl.bbp.nlp.res.tag.GeniaResource"
+        ],
+        "tagset": [
+          "de.julielab.jules.types.GeniaPOSTag"
+        ],
+        "caseSensitive": [
+          "false"
+        ],
+        "useTagdict": [
+          "true"
+        ]
+      }
+    },
+    {
+      "name": "SentenceAnnotator",
+      "description": "Sentence splitter, based on OpenNLP's MaxEnt SentenceDetector, and trained on biomedical corpora (PennBio or Genia corpora).",
+      "class": "ch.epfl.bbp.uima.ae.SentenceAnnotator",
+      "parameters": {
+        "model": [
+          "ch.epfl.bbp.nlp.res.sentence.GeniaResource"
+        ]
+      }
+    },
+    {
+      "name": "TokenAnnotator",
+      "description": "OpenNLP Tokenizer. This engine assumes that sentences have been annotated first.",
+      "class": "ch.epfl.bbp.uima.ae.TokenAnnotator",
+      "parameters": {
+        "model": [
+          "ch.epfl.bbp.nlp.res.token.GeniaResource"
+        ]
+      }
+    },
+    {
+      "name": "BlueBioLemmatizer",
+      "class": "ch.epfl.bbp.uima.ae.BlueBioLemmatizer"
+    }
   ]
 }

--- a/config/pipelines/bluima.chunk_0.1.json
+++ b/config/pipelines/bluima.chunk_0.1.json
@@ -1,7 +1,246 @@
 {
-  "name" : "bluima.chunk",
-  "version" : "0.1",
-  "description" : "tokenizer",
-  "domain" : "bluima",
-  "script": ["ENGINE SentenceAnnotator:0.1;", "ENGINE TokenAnnotator:0.1;", "ENGINE PosTagAnnotator:0.1;", "ENGINE ChunkAnnotator:0.1;"]
+  "name": "bluima.chunk",
+  "version": "0.1",
+  "description": "chunker",
+  "domain": "bluima",
+  "script": [
+    "ENGINE SentenceAnnotator:0.1;",
+    "ENGINE TokenAnnotator:0.1;",
+    "ENGINE PosTagAnnotator:0.1;",
+    "ENGINE ChunkAnnotator:0.1;"
+  ],
+  "tests": [
+    {
+      "comparison": "atLeast",
+      "input": "Switzerland is close to Italy, the land of pasta and Michelangelo. Paris is in France. And Madrid in Spain.",
+      "expected": {
+        "ChunkADJP": [
+          {
+            "begin": 15,
+            "end": 20
+          }
+        ],
+        "ChunkNP": [
+          {
+            "begin": 0,
+            "end": 11
+          },
+          {
+            "begin": 24,
+            "end": 29
+          },
+          {
+            "begin": 31,
+            "end": 39
+          },
+          {
+            "begin": 43,
+            "end": 48
+          },
+          {
+            "begin": 53,
+            "end": 65
+          },
+          {
+            "begin": 67,
+            "end": 72
+          },
+          {
+            "begin": 79,
+            "end": 85
+          },
+          {
+            "begin": 91,
+            "end": 97
+          },
+          {
+            "begin": 101,
+            "end": 106
+          }
+        ],
+        "ChunkPP": [
+          {
+            "begin": 21,
+            "end": 23
+          },
+          {
+            "begin": 40,
+            "end": 42
+          },
+          {
+            "begin": 76,
+            "end": 78
+          },
+          {
+            "begin": 98,
+            "end": 100
+          }
+        ],
+        "ChunkVP": [
+          {
+            "begin": 12,
+            "end": 14
+          },
+          {
+            "begin": 73,
+            "end": 75
+          }
+        ],
+        "Sentence": [
+          {
+            "begin": 0,
+            "end": 66
+          },
+          {
+            "begin": 67,
+            "end": 86
+          },
+          {
+            "begin": 87,
+            "end": 107
+          }
+        ],
+        "Token": [
+          {
+            "begin": 0,
+            "end": 11,
+            "posTag": 792,
+            "pos": "NN"
+          },
+          {
+            "begin": 12,
+            "end": 14,
+            "posTag": 804,
+            "pos": "VBZ"
+          },
+          {
+            "begin": 15,
+            "end": 20,
+            "posTag": 816,
+            "pos": "JJ"
+          },
+          {
+            "begin": 21,
+            "end": 23,
+            "posTag": 828,
+            "pos": "TO"
+          },
+          {
+            "begin": 24,
+            "end": 29,
+            "posTag": 840,
+            "pos": "RB"
+          },
+          {
+            "begin": 29,
+            "end": 30,
+            "posTag": 852,
+            "pos": ","
+          },
+          {
+            "begin": 31,
+            "end": 34,
+            "posTag": 864,
+            "pos": "DT"
+          },
+          {
+            "begin": 35,
+            "end": 39,
+            "posTag": 876,
+            "pos": "NN"
+          },
+          {
+            "begin": 40,
+            "end": 42,
+            "posTag": 888,
+            "pos": "IN"
+          },
+          {
+            "begin": 43,
+            "end": 48,
+            "posTag": 900,
+            "pos": "NN"
+          },
+          {
+            "begin": 49,
+            "end": 52,
+            "posTag": 912,
+            "pos": "CC"
+          },
+          {
+            "begin": 53,
+            "end": 65,
+            "posTag": 924,
+            "pos": "NN"
+          },
+          {
+            "begin": 65,
+            "end": 66,
+            "posTag": 936,
+            "pos": "."
+          },
+          {
+            "begin": 67,
+            "end": 72,
+            "posTag": 948,
+            "pos": "NN"
+          },
+          {
+            "begin": 73,
+            "end": 75,
+            "posTag": 960,
+            "pos": "VBZ"
+          },
+          {
+            "begin": 76,
+            "end": 78,
+            "posTag": 972,
+            "pos": "IN"
+          },
+          {
+            "begin": 79,
+            "end": 85,
+            "posTag": 984,
+            "pos": "NN"
+          },
+          {
+            "begin": 85,
+            "end": 86,
+            "posTag": 996,
+            "pos": "."
+          },
+          {
+            "begin": 87,
+            "end": 90,
+            "posTag": 1008,
+            "pos": "CC"
+          },
+          {
+            "begin": 91,
+            "end": 97,
+            "posTag": 1020,
+            "pos": "NN"
+          },
+          {
+            "begin": 98,
+            "end": 100,
+            "posTag": 1032,
+            "pos": "IN"
+          },
+          {
+            "begin": 101,
+            "end": 106,
+            "posTag": 1044,
+            "pos": "NN"
+          },
+          {
+            "begin": 106,
+            "end": 107,
+            "posTag": 1056,
+            "pos": "."
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/config/pipelines/bluima.lemma_0.1.json
+++ b/config/pipelines/bluima.lemma_0.1.json
@@ -1,0 +1,95 @@
+{
+  "name": "bluima.lemma",
+  "version": "0.1",
+  "description": "lemmatizer",
+  "domain": "bluima",
+  "script": [
+    "ENGINE TokenAnnotator:0.1;",
+    "ENGINE BlueBioLemmatizer:0.1;"
+  ],
+  "tests": [
+    {
+      "comparison": "atLeast",
+      "input": "long form pressure hydrocephalus (NPH) be classify. Thalamic conditioned acoustic areas houses",
+      "expected": {
+        "Token": [
+          {
+            "begin": 0,
+            "end": 4,
+            "lemmaStr": "long"
+          },
+          {
+            "begin": 5,
+            "end": 9,
+            "lemmaStr": "form"
+          },
+          {
+            "begin": 10,
+            "end": 18,
+            "lemmaStr": "pressure"
+          },
+          {
+            "begin": 19,
+            "end": 32,
+            "lemmaStr": "hydrocephalus"
+          },
+          {
+            "begin": 33,
+            "end": 34,
+            "lemmaStr": "("
+          },
+          {
+            "begin": 34,
+            "end": 37,
+            "lemmaStr": "NPH"
+          },
+          {
+            "begin": 37,
+            "end": 38,
+            "lemmaStr": ")"
+          },
+          {
+            "begin": 39,
+            "end": 41,
+            "lemmaStr": "be"
+          },
+          {
+            "begin": 42,
+            "end": 50,
+            "lemmaStr": "classify"
+          },
+          {
+            "begin": 50,
+            "end": 51,
+            "lemmaStr": "."
+          },
+          {
+            "begin": 52,
+            "end": 60,
+            "lemmaStr": "thalamic"
+          },
+          {
+            "begin": 61,
+            "end": 72,
+            "lemmaStr": "condition"
+          },
+          {
+            "begin": 73,
+            "end": 81,
+            "lemmaStr": "acoustic"
+          },
+          {
+            "begin": 82,
+            "end": 87,
+            "lemmaStr": "area"
+          },
+          {
+            "begin": 88,
+            "end": 94,
+            "lemmaStr": "house"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/config/pipelines/bluima.opennlp_0.1.json
+++ b/config/pipelines/bluima.opennlp_0.1.json
@@ -1,7 +1,0 @@
-{
-  "name" : "bluima.opennlp",
-  "version" : "0.1",
-  "description" : "OpenNLP Annotator",
-  "domain" : "bluima",
-  "script": ["ENGINE SentenceAnnotator:0.1;", "ENGINE TokenAnnotator:0.1;", "ENGINE PosTagAnnotator:0.1;", "ENGINE ChunkAnnotator:0.1;"]
-}

--- a/config/pipelines/bluima.pos_0.1.json
+++ b/config/pipelines/bluima.pos_0.1.json
@@ -1,7 +1,173 @@
 {
-  "name" : "bluima.pos",
-  "version" : "0.1",
-  "description" : "tokenizer",
-  "domain" : "bluima",
-  "script": ["ENGINE SentenceAnnotator:0.1;", "ENGINE TokenAnnotator:0.1;", "ENGINE PosTagAnnotator:0.1;"]
+  "name": "bluima.pos",
+  "version": "0.1",
+  "description": "PoS Tagger",
+  "domain": "bluima",
+  "script": [
+    "ENGINE SentenceAnnotator:0.1;",
+    "ENGINE TokenAnnotator:0.1;",
+    "ENGINE PosTagAnnotator:0.1;"
+  ],
+  "tests": [
+    {
+      "comparison": "atLeast",
+      "input": "Switzerland is close to Italy, the land of pasta and Michelangelo. Paris is in France. And Madrid in Spain.",
+      "expected": {
+        "Sentence": [
+          {
+            "begin": 0,
+            "end": 66
+          },
+          {
+            "begin": 67,
+            "end": 86
+          },
+          {
+            "begin": 87,
+            "end": 107
+          }
+        ],
+        "Token": [
+          {
+            "begin": 0,
+            "end": 11,
+            "posTag": 792,
+            "pos": "NN"
+          },
+          {
+            "begin": 12,
+            "end": 14,
+            "posTag": 804,
+            "pos": "VBZ"
+          },
+          {
+            "begin": 15,
+            "end": 20,
+            "posTag": 816,
+            "pos": "JJ"
+          },
+          {
+            "begin": 21,
+            "end": 23,
+            "posTag": 828,
+            "pos": "TO"
+          },
+          {
+            "begin": 24,
+            "end": 29,
+            "posTag": 840,
+            "pos": "RB"
+          },
+          {
+            "begin": 29,
+            "end": 30,
+            "posTag": 852,
+            "pos": ","
+          },
+          {
+            "begin": 31,
+            "end": 34,
+            "posTag": 864,
+            "pos": "DT"
+          },
+          {
+            "begin": 35,
+            "end": 39,
+            "posTag": 876,
+            "pos": "NN"
+          },
+          {
+            "begin": 40,
+            "end": 42,
+            "posTag": 888,
+            "pos": "IN"
+          },
+          {
+            "begin": 43,
+            "end": 48,
+            "posTag": 900,
+            "pos": "NN"
+          },
+          {
+            "begin": 49,
+            "end": 52,
+            "posTag": 912,
+            "pos": "CC"
+          },
+          {
+            "begin": 53,
+            "end": 65,
+            "posTag": 924,
+            "pos": "NN"
+          },
+          {
+            "begin": 65,
+            "end": 66,
+            "posTag": 936,
+            "pos": "."
+          },
+          {
+            "begin": 67,
+            "end": 72,
+            "posTag": 948,
+            "pos": "NN"
+          },
+          {
+            "begin": 73,
+            "end": 75,
+            "posTag": 960,
+            "pos": "VBZ"
+          },
+          {
+            "begin": 76,
+            "end": 78,
+            "posTag": 972,
+            "pos": "IN"
+          },
+          {
+            "begin": 79,
+            "end": 85,
+            "posTag": 984,
+            "pos": "NN"
+          },
+          {
+            "begin": 85,
+            "end": 86,
+            "posTag": 996,
+            "pos": "."
+          },
+          {
+            "begin": 87,
+            "end": 90,
+            "posTag": 1008,
+            "pos": "CC"
+          },
+          {
+            "begin": 91,
+            "end": 97,
+            "posTag": 1020,
+            "pos": "NN"
+          },
+          {
+            "begin": 98,
+            "end": 100,
+            "posTag": 1032,
+            "pos": "IN"
+          },
+          {
+            "begin": 101,
+            "end": 106,
+            "posTag": 1044,
+            "pos": "NN"
+          },
+          {
+            "begin": 106,
+            "end": 107,
+            "posTag": 1056,
+            "pos": "."
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/config/pipelines/bluima.sentence_0.1.json
+++ b/config/pipelines/bluima.sentence_0.1.json
@@ -1,7 +1,31 @@
 {
-  "name" : "bluima.sentence",
-  "version" : "0.1",
-  "description" : "sentence splitter",
-  "domain" : "bluima",
-  "script": ["ENGINE SentenceAnnotator:0.1;"]
+  "name": "bluima.sentence",
+  "version": "0.1",
+  "description": "sentence splitter",
+  "domain": "bluima",
+  "script": [
+    "ENGINE SentenceAnnotator:0.1;"
+  ],
+  "tests": [
+    {
+      "comparison": "atLeast",
+      "input": "Switzerland is close to Italy, the land of pasta and Michelangelo. Paris is in France. And Madrid in Spain.",
+      "expected": {
+        "Sentence": [
+          {
+            "begin": 0,
+            "end": 66
+          },
+          {
+            "begin": 67,
+            "end": 86
+          },
+          {
+            "begin": 87,
+            "end": 107
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/config/pipelines/bluima.token_0.1.json
+++ b/config/pipelines/bluima.token_0.1.json
@@ -1,7 +1,111 @@
 {
-  "name" : "bluima.token",
-  "version" : "0.1",
-  "description" : "tokenizer",
-  "domain" : "bluima",
-  "script": ["ENGINE TokenAnnotator:0.1;"]
+  "name": "bluima.token",
+  "version": "0.1",
+  "description": "tokenizer",
+  "domain": "bluima",
+  "script": [
+    "ENGINE TokenAnnotator:0.1;"
+  ],
+  "tests": [
+    {
+      "comparison": "atLeast",
+      "input": "Switzerland is close to Italy, the land of pasta and Michelangelo. Paris is in France. And Madrid in Spain.",
+      "expected": {
+        "Token": [
+          {
+            "begin": 0,
+            "end": 11
+          },
+          {
+            "begin": 12,
+            "end": 14
+          },
+          {
+            "begin": 15,
+            "end": 20
+          },
+          {
+            "begin": 21,
+            "end": 23
+          },
+          {
+            "begin": 24,
+            "end": 29
+          },
+          {
+            "begin": 29,
+            "end": 30
+          },
+          {
+            "begin": 31,
+            "end": 34
+          },
+          {
+            "begin": 35,
+            "end": 39
+          },
+          {
+            "begin": 40,
+            "end": 42
+          },
+          {
+            "begin": 43,
+            "end": 48
+          },
+          {
+            "begin": 49,
+            "end": 52
+          },
+          {
+            "begin": 53,
+            "end": 65
+          },
+          {
+            "begin": 65,
+            "end": 66
+          },
+          {
+            "begin": 67,
+            "end": 72
+          },
+          {
+            "begin": 73,
+            "end": 75
+          },
+          {
+            "begin": 76,
+            "end": 78
+          },
+          {
+            "begin": 79,
+            "end": 85
+          },
+          {
+            "begin": 85,
+            "end": 86
+          },
+          {
+            "begin": 87,
+            "end": 90
+          },
+          {
+            "begin": 91,
+            "end": 97
+          },
+          {
+            "begin": 98,
+            "end": 100
+          },
+          {
+            "begin": 101,
+            "end": 106
+          },
+          {
+            "begin": 106,
+            "end": 107
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/src/main/java/org/sherlok/SherlokServer.java
+++ b/src/main/java/org/sherlok/SherlokServer.java
@@ -208,9 +208,9 @@ public class SherlokServer {
 
                     for (PipelineTest test : pipeline.getPipelineDef()
                             .getTests()) {
-                        String systemOut = pipeline.annotate(test.getInput());
+                        String actual = pipeline.annotate(test.getInput());
                         SherlokTests.assertEquals(test.getExpected(),
-                                systemOut, test.getComparison());
+                                actual, test.getComparison());
                     }
                     return map("status", "passed");
 


### PR DESCRIPTION
This adds missing tests for OpenNLP pipelines, fixes an issue with test comparator 'at least' (1) and adds BlueBioLemmatizer pipeline.

(1): the fix allow properties such as `"componentId" : "de.julielab.jules.OpenNLPTokenizer"` to be ignored from tests.